### PR TITLE
Fix the way static serve works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-server/static

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "scripts": {
     "build": "npm run build --workspaces",
-    "postbuild": "shx cp -r client/dist server/static",
     "start": "npm run start --workspace server",
     "dev": "concurrently \"npm run dev --workspace client\" \"npm run dev --workspace server\"",
     "format": "prettier --write .",

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+client/
+static/

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,11 +23,13 @@ app.post('/data/match', async(req,res) => {
     
 });
 
+app.use(express.static('static'));
+
 // Since this is the fallback is must go after all other routes
 if (DEV) {
     app.use('/', createProxyMiddleware('http://localhost:5173', { ws: true }));
 } else {
-    app.use(express.static('static'));
+    app.use(express.static('../client/dist'));
 
     app.get('/', (_, res) => {
         res.sendFile('static/index.html');


### PR DESCRIPTION
This allows serving static files in dev mode.
This will require everyone who has run `npm run build` to delete the `server/static` folder
